### PR TITLE
Add Enemy Entity

### DIFF
--- a/src/Enemy.cpp
+++ b/src/Enemy.cpp
@@ -47,16 +47,18 @@ bool Enemy::isGrounded(GameState &state) {
   return false;
 }
 
-void Enemy::update(GameState &state) {
-  float dt = state.getDeltaTime();
-  bool grounded = isGrounded(state);
-
-  MoveEnemy(vx * dt, vy * dt, state);
-
+bool Enemy::checkPlayerCollision(float px, float py) {
   sf::Vector2<float> pos = shape.getPosition();
 
-  // std::cout << vx << "," << vy << "\n";
-  // std::cout << pos.x << "," << pos.y << "\n";
+  float distance = ((pos.x - px) * (pos.x - px)) + ((pos.y - py) * (pos.y - py));
+  return distance < 50 * 50;
+}
+
+void Enemy::update(GameState &state) {
+  float dt = state.getDeltaTime();
+  isGrounded(state);
+
+  MoveEnemy(vx * dt, vy * dt, state);
 }
 
 void Enemy::MoveEnemy(float xoffset, float yoffset, GameState &state) {
@@ -78,7 +80,6 @@ void Enemy::MoveEnemy(float xoffset, float yoffset, GameState &state) {
     if (state.checkCollision(pos.x + i, pos.y + newY)) {
       yoffset = abs(yoffset);
       vy = -yoffset;
-
       break;
     }
   }

--- a/src/Enemy.cpp
+++ b/src/Enemy.cpp
@@ -1,5 +1,6 @@
 #include "Enemy.h"
 #include "GameState.h"
+#include "SFML/Graphics/Color.hpp"
 #include <iostream>
 
 #define MAX_SPEED 400.0f
@@ -49,10 +50,25 @@ bool Enemy::isGrounded(GameState &state) {
 }
 
 bool Enemy::checkPlayerCollision(float px, float py) {
+  if (isDying) return false;
+
   sf::Vector2<float> pos = shape.getPosition();
 
   float distance = ((pos.x - px) * (pos.x - px)) + ((pos.y - py) * (pos.y - py));
   return distance < CELL_SIZE * CELL_SIZE;
+}
+
+sf::RectangleShape Enemy::getShape() { return shape; }
+
+
+void Enemy::die() {
+  if (!isDying) {
+    shape.setFillColor(sf::Color::Yellow); // replace with change to dead texture
+    isDying = true;
+  }
+
+  // disable horizontal movement
+  vx = 0;
 }
 
 void Enemy::update(GameState &state) {

--- a/src/Enemy.cpp
+++ b/src/Enemy.cpp
@@ -1,0 +1,87 @@
+#include "Enemy.h"
+#include <iostream>
+
+#define MAX_SPEED 400.0f
+#define DECEL_RATE 3000.0f
+#define ACCEL_RATE 3000.0f
+#define JUMP_FORCE 1150.0f
+#define AIR_DECEL_RATE (DECEL_RATE * 1.0f)
+#define MAX_AIR_SPEED (MAX_SPEED * 5.0f)
+
+int Enemy::roundAwayFromZero(float x) { return x < 0 ? floor(x) : ceil(x); }
+
+Enemy::Enemy(int cx, int cy) {
+  shape = sf::RectangleShape(sf::Vector2f(50.0f, 50.0f));
+  shape.setFillColor(sf::Color::Red);
+  shape.setPosition(1665, 0);
+
+  vx = MAX_SPEED;
+  vy = MAX_AIR_SPEED;
+}
+
+Enemy::~Enemy() {}
+
+void Enemy::draw(sf::RenderTarget &target, sf::RenderStates states) const {
+  target.draw(shape, states);
+}
+
+bool Enemy::isGrounded(GameState &state) {
+  sf::Vector2<float> pos = shape.getPosition();
+  sf::Vector2<float> size = shape.getSize();
+
+  for (int i = 0; i < size.x; i++) {
+    if (state.checkCollision(pos.x + i, pos.y + size.y + 1)) {
+      float newY = pos.y + size.y;
+      while (state.checkCollision(pos.x + i, newY)) {
+        newY -= 1;
+      }
+
+      shape.setPosition(pos.x, newY - 50);
+
+      vy = 0;
+      return true;
+    }
+  }
+
+  vy = MAX_AIR_SPEED;
+  return false;
+}
+
+void Enemy::update(GameState &state) {
+  float dt = state.getDeltaTime();
+  bool grounded = isGrounded(state);
+
+  MoveEnemy(vx * dt, vy * dt, state);
+
+  sf::Vector2<float> pos = shape.getPosition();
+
+  // std::cout << vx << "," << vy << "\n";
+  // std::cout << pos.x << "," << pos.y << "\n";
+}
+
+void Enemy::MoveEnemy(float xoffset, float yoffset, GameState &state) {
+  sf::Vector2<float> pos = shape.getPosition();
+  sf::Vector2<float> size = shape.getSize();
+
+  int newX = roundAwayFromZero(xoffset);
+  for (int i = 0; i <= size.y - 3; i++) {
+    if (state.checkCollision(pos.x + newX, pos.y + i) ||
+        state.checkCollision(pos.x + size.x + newX, pos.y + i)) {
+      xoffset *= -1;
+      vx *= -1;
+      break;
+    }
+  }
+
+  int newY = roundAwayFromZero(yoffset);
+  for (int i = 0; i <= size.x; i++) {
+    if (state.checkCollision(pos.x + i, pos.y + newY)) {
+      yoffset = abs(yoffset);
+      vy = -yoffset;
+
+      break;
+    }
+  }
+
+  shape.setPosition(pos.x + xoffset, pos.y + yoffset);
+}

--- a/src/Enemy.cpp
+++ b/src/Enemy.cpp
@@ -13,18 +13,34 @@
 int Enemy::roundAwayFromZero(float x) { return x < 0 ? floor(x) : ceil(x); }
 
 Enemy::Enemy(int cx, int cy) {
+  spawn_x = cx;
+  spawn_y = cy;
+
   shape = sf::RectangleShape(sf::Vector2f(CELL_SIZE, CELL_SIZE));
   shape.setFillColor(sf::Color::Red);
-  shape.setPosition(1665, 0);
+  shape.setPosition(cx, cy);
 
   vx = MAX_SPEED;
   vy = MAX_AIR_SPEED;
+
+  isDying = false;
 }
 
 Enemy::~Enemy() {}
 
 void Enemy::draw(sf::RenderTarget &target, sf::RenderStates states) const {
   target.draw(shape, states);
+}
+
+void Enemy::reset() {
+  shape = sf::RectangleShape(sf::Vector2f(CELL_SIZE, CELL_SIZE));
+  shape.setFillColor(sf::Color::Red);
+  shape.setPosition(spawn_x, spawn_y);
+
+  vx = MAX_SPEED;
+  vy = MAX_AIR_SPEED;
+
+  isDying = false;
 }
 
 bool Enemy::isGrounded(GameState &state) {

--- a/src/Enemy.cpp
+++ b/src/Enemy.cpp
@@ -1,4 +1,5 @@
 #include "Enemy.h"
+#include "GameState.h"
 #include <iostream>
 
 #define MAX_SPEED 400.0f
@@ -11,7 +12,7 @@
 int Enemy::roundAwayFromZero(float x) { return x < 0 ? floor(x) : ceil(x); }
 
 Enemy::Enemy(int cx, int cy) {
-  shape = sf::RectangleShape(sf::Vector2f(50.0f, 50.0f));
+  shape = sf::RectangleShape(sf::Vector2f(CELL_SIZE, CELL_SIZE));
   shape.setFillColor(sf::Color::Red);
   shape.setPosition(1665, 0);
 
@@ -36,7 +37,7 @@ bool Enemy::isGrounded(GameState &state) {
         newY -= 1;
       }
 
-      shape.setPosition(pos.x, newY - 50);
+      shape.setPosition(pos.x, newY - CELL_SIZE);
 
       vy = 0;
       return true;
@@ -51,7 +52,7 @@ bool Enemy::checkPlayerCollision(float px, float py) {
   sf::Vector2<float> pos = shape.getPosition();
 
   float distance = ((pos.x - px) * (pos.x - px)) + ((pos.y - py) * (pos.y - py));
-  return distance < 50 * 50;
+  return distance < CELL_SIZE * CELL_SIZE;
 }
 
 void Enemy::update(GameState &state) {

--- a/src/Enemy.h
+++ b/src/Enemy.h
@@ -1,0 +1,30 @@
+#include "GameState.h"
+#include "SFML/Graphics/Drawable.hpp"
+#include "SFML/Graphics/RectangleShape.hpp"
+
+class Enemy : public sf::Drawable {
+public:
+  Enemy(int cx, int cy);
+  Enemy(Enemy &&) = default;
+  Enemy(const Enemy &) = default;
+  Enemy &operator=(Enemy &&) = default;
+  Enemy &operator=(const Enemy &) = default;
+  ~Enemy();
+
+  void update(GameState &state);
+
+private:
+  // Velocities
+  float vx, vy;
+
+  // override draw
+  virtual void draw(sf::RenderTarget &target, sf::RenderStates states) const;
+
+  // Underlying SFML object
+  sf::RectangleShape shape;
+
+  bool isGrounded(GameState &state);
+  void MoveEnemy(float xoffset, float yoffset, GameState &state);
+  int roundAwayFromZero(float x);
+};
+

--- a/src/Enemy.h
+++ b/src/Enemy.h
@@ -15,7 +15,10 @@ public:
   bool checkPlayerCollision(float px, float py);
   sf::RectangleShape getShape();
   void die();
+  void reset();
 private:
+  int spawn_x, spawn_y;
+
   // Velocities
   float vx, vy;
 

--- a/src/Enemy.h
+++ b/src/Enemy.h
@@ -13,7 +13,8 @@ public:
 
   void update(GameState &state);
   bool checkPlayerCollision(float px, float py);
-
+  sf::RectangleShape getShape();
+  void die();
 private:
   // Velocities
   float vx, vy;
@@ -23,6 +24,8 @@ private:
 
   // Underlying SFML object
   sf::RectangleShape shape;
+
+  bool isDying;
 
   bool isGrounded(GameState &state);
   void MoveEnemy(float xoffset, float yoffset, GameState &state);

--- a/src/Enemy.h
+++ b/src/Enemy.h
@@ -12,6 +12,7 @@ public:
   ~Enemy();
 
   void update(GameState &state);
+  bool checkPlayerCollision(float px, float py);
 
 private:
   // Velocities

--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -3,6 +3,7 @@
 #include "SFML/System/Vector2.hpp"
 #include "SFML/Window/Keyboard.hpp"
 #include <SFML/Graphics.hpp>
+#include <iostream>
 
 #include "GameState.h"
 #include "Player.h"
@@ -117,6 +118,18 @@ void GameState::runGame() {
     // entity updates
     player.update(*this);
     enemy.update(*this);
+
+    sf::Vector2f pos = player.getShape().getPosition();
+    sf::Vector2f epos = enemy.getShape().getPosition();
+
+    if (enemy.checkPlayerCollision(pos.x, pos.y)) {
+      if (pos.y < epos.y + (CELL_SIZE / 2)) {
+        enemy.die();
+        player.jump();
+      } else {
+        player.die();
+      }
+    }
 
     // Draw everything
     window.clear(sf::Color::White); // Clear the window with white color

--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -3,13 +3,18 @@
 #include "SFML/System/Vector2.hpp"
 #include "SFML/Window/Keyboard.hpp"
 #include <SFML/Graphics.hpp>
+#include <algorithm>
 #include <iostream>
+#include <vector>
 
+#include "Enemy.h"
 #include "GameState.h"
 #include "Player.h"
-#include "Enemy.h"
 
-GameState::GameState() { clock = sf::Clock(); resetLevel = false; }
+GameState::GameState() {
+  clock = sf::Clock();
+  resetLevel = false;
+}
 
 float GameState::getDeltaTime() {
   // not using clock.getElapsedTime() since we want since last recorded frame
@@ -87,7 +92,13 @@ void GameState::runGame() {
   }
 
   Player player = Player(0, 0);
-  Enemy enemy = Enemy(100, 100);
+
+  std::vector<Enemy> enemies;
+
+  for (int i = 0; i < 1; i++) {
+    Enemy enemy = Enemy((i + 1) * 1500, 0);
+    enemies.push_back(enemy);
+  }
 
   sf::Sprite backgroundSprite(backgroundTexture);
   backgroundSprite.setPosition(0, 0);
@@ -107,6 +118,9 @@ void GameState::runGame() {
     if (resetLevel) {
       player = Player(0, 0);
       view = sf::View(sf::FloatRect(0, 0, WINDOW_WIDTH, WINDOW_HEIGHT));
+      for (auto &enemy : enemies) {
+        enemy.reset();
+      }
 
       resetLevel = false;
     }
@@ -117,25 +131,30 @@ void GameState::runGame() {
 
     // entity updates
     player.update(*this);
-    enemy.update(*this);
+    for (auto &enemy : enemies) {
+      enemy.update(*this);
 
-    sf::Vector2f pos = player.getShape().getPosition();
-    sf::Vector2f epos = enemy.getShape().getPosition();
+      sf::Vector2f pos = player.getShape().getPosition();
+      sf::Vector2f epos = enemy.getShape().getPosition();
 
-    if (enemy.checkPlayerCollision(pos.x, pos.y)) {
-      if (pos.y < epos.y + (CELL_SIZE / 2)) {
-        enemy.die();
-        player.jump();
-      } else {
-        player.die();
+      if (enemy.checkPlayerCollision(pos.x, pos.y)) {
+         std::cout << pos.y - epos.y << "\n";
+        if (pos.y - epos.y < -(CELL_SIZE / 2)) {
+          enemy.die();
+          player.jump();
+        } else {
+          player.die();
+        }
       }
     }
 
     // Draw everything
     window.clear(sf::Color::White); // Clear the window with white color
-    window.draw(backgroundSprite); // Draw background first
+    window.draw(backgroundSprite);  // Draw background first
+    for (Enemy enemy : enemies) {
+      window.draw(enemy);
+    }
     window.draw(player);
-    window.draw(enemy);
     window.display();
   }
 }

--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -3,10 +3,10 @@
 #include "SFML/System/Vector2.hpp"
 #include "SFML/Window/Keyboard.hpp"
 #include <SFML/Graphics.hpp>
-#include <iostream>
 
 #include "GameState.h"
 #include "Player.h"
+#include "Enemy.h"
 
 GameState::GameState() { clock = sf::Clock(); resetLevel = false; }
 
@@ -86,6 +86,7 @@ void GameState::runGame() {
   }
 
   Player player = Player(0, 0);
+  Enemy enemy = Enemy(100, 100);
 
   sf::Sprite backgroundSprite(backgroundTexture);
   backgroundSprite.setPosition(0, 0);
@@ -115,11 +116,13 @@ void GameState::runGame() {
 
     // entity updates
     player.update(*this);
+    enemy.update(*this);
 
     // Draw everything
     window.clear(sf::Color::White); // Clear the window with white color
     window.draw(backgroundSprite); // Draw background first
     window.draw(player);
+    window.draw(enemy);
     window.display();
   }
 }

--- a/src/GameState.h
+++ b/src/GameState.h
@@ -7,8 +7,9 @@
 
 #define WINDOW_WIDTH 1280
 #define WINDOW_HEIGHT 720
-#define VIEW_SCROLL_MARGIN 200 
-#define VIEW_SCROLL_MARGIN_FROM_CENTER ((WINDOW_WIDTH / 2.0f) - VIEW_SCROLL_MARGIN)
+#define VIEW_SCROLL_MARGIN 200
+#define VIEW_SCROLL_MARGIN_FROM_CENTER                                         \
+  ((WINDOW_WIDTH / 2.0f) - VIEW_SCROLL_MARGIN)
 
 class GameState {
 public:

--- a/src/GameState.h
+++ b/src/GameState.h
@@ -10,6 +10,7 @@
 #define VIEW_SCROLL_MARGIN 200
 #define VIEW_SCROLL_MARGIN_FROM_CENTER                                         \
   ((WINDOW_WIDTH / 2.0f) - VIEW_SCROLL_MARGIN)
+#define CELL_SIZE 50.0f
 
 class GameState {
 public:

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -39,7 +39,13 @@ bool Player::isGrounded(GameState &state) {
   sf::Vector2<float> size = shape.getSize();
 
   for (int i = 0; i < shape.getSize().x; i++) {
-    if (state.checkCollision(pos.x + i, pos.y + size.y)) {
+    if (state.checkCollision(pos.x + i, pos.y + size.y + 1)) {
+      float newY = pos.y + size.y;
+      while (state.checkCollision(pos.x + i, newY)) {
+        newY -= 1;
+      }
+      shape.setPosition(pos.x, newY - 50);
+
       vy = 0;
       return true;
     }
@@ -112,8 +118,8 @@ void Player::update(GameState &state) {
 
   sf::Vector2<float> pos = shape.getPosition();
 
-  std::cout << vx << "," << vy << "\n";
-  std::cout << pos.x << "," << pos.y << "\n";
+  // std::cout << vx << "," << vy << "\n";
+  // std::cout << pos.x << "," << pos.y << "\n";
 }
 
 void Player::MovePlayer(float xoffset, float yoffset, GameState &state) {

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -79,6 +79,7 @@ bool Player::shouldDie() {
   return shape.getPosition().y >= 665;
 }
 void Player::jump() { vy = JUMP_FORCE; }
+
 void Player::die() {
   if (!isDying) {
     // on first invocation, jump

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -12,12 +12,12 @@
 #define AIR_DECEL_RATE (DECEL_RATE * 1.0f)
 #define MAX_AIR_SPEED (MAX_SPEED * 5.0f)
 
-#define GROUND_HEIGHT (620 - 50)
+#define GROUND_HEIGHT (620 - CELL_SIZE)
 
 int roundAwayFromZero(float x) { return x < 0 ? floor(x) : ceil(x); }
 
 Player::Player(int cx, int cy) {
-  shape = sf::RectangleShape(sf::Vector2f(50.0f, 50.0f));
+  shape = sf::RectangleShape(sf::Vector2f(CELL_SIZE, CELL_SIZE));
   shape.setFillColor(sf::Color::Black);
   shape.setPosition(cx, cy);
   isDying = false;
@@ -44,7 +44,7 @@ bool Player::isGrounded(GameState &state) {
       while (state.checkCollision(pos.x + i, newY)) {
         newY -= 1;
       }
-      shape.setPosition(pos.x, newY - 50);
+      shape.setPosition(pos.x, newY - CELL_SIZE);
 
       vy = 0;
       return true;

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -116,7 +116,7 @@ void Player::update(GameState &state) {
 
   MovePlayer(vx * dt, -vy * dt, state);
 
-  sf::Vector2<float> pos = shape.getPosition();
+  // sf::Vector2<float> pos = shape.getPosition();
 
   // std::cout << vx << "," << vy << "\n";
   // std::cout << pos.x << "," << pos.y << "\n";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,3 @@
-#include <iostream>
 #include "GameState.h"
 
 using namespace std;


### PR DESCRIPTION
Adds
- enemy entitiy
- enemy traversal in ping-pong-like manner
- enemy collisions
- enemy death from player
- player death from enemy
- enemy reset on level reset


Currently, most code is duplicated from `Player.h`. Can abstract it out or leave it. 

Also temporarily fixes the player stuck in ground bug. If stuck in ground, keeps moving player upward until not stuck.


https://github.com/ArsalaanAli/SuperMarioClone/assets/96938305/a36e25af-47b9-40f5-8eb9-59bc9ee21967

https://github.com/ArsalaanAli/SuperMarioClone/assets/96938305/7f31ade9-77a5-446f-8422-17001bb13915

https://github.com/ArsalaanAli/SuperMarioClone/assets/96938305/d5d632d7-c889-4333-a8fa-7201f609acf0



