### PR TITLE
Add Powerups

### DIFF
--- a/src/Level.h
+++ b/src/Level.h
@@ -74,6 +74,11 @@ public:
    * @param win If the player won the level. If false, resets the level.
    */
   void endLevel(bool win);
+
+  /**
+   * @brief Check if a powerup should be spawned.
+   */
+  void checkPowerUp();
 private:
   /**
    * @brief the internal clock of the level.
@@ -95,6 +100,11 @@ private:
   sf::Texture texture;
 
   /**
+   * @brief The image of the level.
+   */
+  sf::Image img;
+
+  /**
    * @brief The collision map of the level.
    */
   sf::Image collisionMap;
@@ -109,6 +119,16 @@ private:
    * @brief The collection of coins in the level.
    */
   std::vector<sf::Sprite> coins;
+
+  /**
+   * @brief The texture of the powerups.
+   */
+  sf::Texture powerUpTexture;
+
+  /**
+   * @brief The collection of powerups in the level.
+   */
+  std::vector<sf::Sprite> powerUps;
 
   /**
    * @brief The marked end of the currently loaded level.

--- a/src/Player.h
+++ b/src/Player.h
@@ -14,6 +14,8 @@ using namespace std;
 #define JUMP_FORCE 1150.0f
 #define AIR_DECEL_RATE (DECEL_RATE * 1.0f)
 #define MAX_AIR_SPEED (MAX_SPEED * 5.0f)
+#define POWERUP_SPEED_FACTOR 2.0f
+#define POWERUP_TIME 5.0f
 
 class Player : public sf::Drawable {
 public:
@@ -48,6 +50,11 @@ public:
   void update();
 
   /**
+   * @brief Activate the player's powerup.
+   */
+  void activatePowerup();
+
+  /**
    * @brief Get the Shape object
    *
    * @return The player's shape.
@@ -76,6 +83,11 @@ private:
    * @brief Flag for whether the player is dying.
    */
   bool isDying;
+
+  /**
+   * @brief The player's powerup time remaining. Recorded in seconds.
+   */
+  float powerUpTime;
 
   /**
    * @brief The player's shape.
@@ -116,6 +128,11 @@ private:
    * @brief The player's animation time.
    */
   float animationTime;
+
+  /**
+   * @brief Flag for whether the player is powered up.
+   */
+  bool powerUpActive;
 
   /**
    * @brief Animate the player.


### PR DESCRIPTION
Adds green speed powerups. Will only spawn if colliding with [?] blocks from the bottom (20% chance of spawn). 

Bugs:
- Right now, you can spam break the same [?] block to keep trying to spawn a powerup. (could keep as intentional game design lol)
